### PR TITLE
[16.0][FIX] display error in case of no available shares

### DIFF
--- a/cooperator/readme/newsfragments/86.bugfix.17.rst
+++ b/cooperator/readme/newsfragments/86.bugfix.17.rst
@@ -1,0 +1,2 @@
+Display an error message instead of failing when trying to create a
+subscription request from a partner and no share products are available.

--- a/cooperator/wizard/partner_create_subscription.py
+++ b/cooperator/wizard/partner_create_subscription.py
@@ -29,8 +29,12 @@ class PartnerCreateSubscription(models.TransientModel):
                 domain.append(("by_company", "=", True))
             else:
                 domain.append(("by_individual", "=", True))
-
-        return self.env["product.product"].search(domain)[0]
+        products = self.env["product.product"].search(domain)
+        if not products:
+            raise UserError(
+                _("No default share product found for this type of partner.")
+            )
+        return products[0]
 
     def _get_representative(self):
         partner = self._get_partner()


### PR DESCRIPTION
display an error message instead of failing when trying to create a subscription request from a partner and no share products are available.